### PR TITLE
Fix deprecated when statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,19 +157,19 @@
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
   register: ler53_intermediate_download_task
-  when: ler53_intermediate_download
+  when: ler53_intermediate_download == True
 
 - name: get content of the certificate
   command: "cat {{ ler53_cert_dir }}/{{ ler53_cert_file_name }}"
   register: ler53_certificate_content
   changed_when: false
-  when: ler53_intermediate_download
+  when: ler53_intermediate_download == True
 
 - name: get content of the intermediate CA
   command: "cat {{ ler53_cert_dir }}/{{ ler53_intermediate_file_name }}"
   register: ler53_intermediate_content
   changed_when: false
-  when: ler53_intermediate_download
+  when: ler53_intermediate_download == True
 
 - name: create a file with the certificate and intermediate CA concatenated
   copy:
@@ -178,4 +178,4 @@
     owner: "{{ ler53_cert_files_owner }}"
     group: "{{ ler53_cert_files_group }}"
     mode: "{{ ler53_cert_files_mode }}"
-  when: ler53_intermediate_download
+  when: ler53_intermediate_download == True


### PR DESCRIPTION
```
[DEPRECATION WARNING]: evaluating ler53_intermediate_download as a bare variable, this behaviour will go away and you 
might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This    
feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
 ansible.cfg.
```